### PR TITLE
feat: `flatMap`

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Full API documentation can be found [here](https://deno.land/x/iter/mod.ts)
 - [x] `some`
 - [x] `forEach`
 - [x] `flat`
-- [ ] `flatMap`
+- [x] `flatMap`
 
 ### Currently not being considered
 

--- a/fp.ts
+++ b/fp.ts
@@ -23,6 +23,7 @@ export const norm = reducers.norm;
 
 // Transformers
 export const map = curryIterFunction(transformers.map);
+export const flatMap = curryIterFunction(transformers.flatMap);
 export const take = curryIterFunction(transformers.take);
 export const until = curryIterFunction(transformers.until);
 export const filter = curryIterFunction(transformers.filter);


### PR DESCRIPTION
# Summary

implements lazy flatMap.

## Tests
 added test against `flatMap` which compares against reference implementations:
   - [flatMap][flatMap] (supposed to be identical to map followed by flat)
   - map followed by flat
   - library map followed by library flat

[flatMap]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap