### PR TITLE
chore(deps): `std/assert@0.208.0`

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,9 +1,17 @@
 {
   "version": "3",
   "remote": {
-    "https://deno.land/std@0.84.0/fmt/colors.ts": "d253f2367e5feebcf0f49676533949c09ea07a2d95fb74958f6f5c1c22fbec49",
-    "https://deno.land/std@0.84.0/testing/_diff.ts": "961eaf6d9f5b0a8556c9d835bbc6fa74f5addd7d3b02728ba7936ff93364f7a3",
-    "https://deno.land/std@0.84.0/testing/asserts.ts": "de942b2e1cb6dac1c1c4a7b698be017337e2e2cc2252ae0a6d215c5befde1e82",
+    "https://deno.land/std@0.208.0/assert/_constants.ts": "8a9da298c26750b28b326b297316cdde860bc237533b07e1337c021379e6b2a9",
+    "https://deno.land/std@0.208.0/assert/_diff.ts": "58e1461cc61d8eb1eacbf2a010932bf6a05b79344b02ca38095f9b805795dc48",
+    "https://deno.land/std@0.208.0/assert/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.208.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
+    "https://deno.land/std@0.208.0/assert/assert_array_includes.ts": "6856d7f2c3544bc6e62fb4646dfefa3d1df5ff14744d1bca19f0cbaf3b0d66c9",
+    "https://deno.land/std@0.208.0/assert/assert_equals.ts": "d8ec8a22447fbaf2fc9d7c3ed2e66790fdb74beae3e482855d75782218d68227",
+    "https://deno.land/std@0.208.0/assert/assert_is_error.ts": "c21113094a51a296ffaf036767d616a78a2ae5f9f7bbd464cd0197476498b94b",
+    "https://deno.land/std@0.208.0/assert/assert_throws.ts": "63784e951475cb7bdfd59878cd25a0931e18f6dc32a6077c454b2cd94f4f4bcd",
+    "https://deno.land/std@0.208.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
+    "https://deno.land/std@0.208.0/assert/equal.ts": "9f1a46d5993966d2596c44e5858eec821859b45f783a5ee2f7a695dfc12d8ece",
+    "https://deno.land/std@0.208.0/fmt/colors.ts": "34b3f77432925eb72cf0bfb351616949746768620b8e5ead66da532f93d10ba2",
     "https://deno.land/x/copb@v1.0.1/lib/copb.ts": "49c807431a38eda063b2f99f69c8ebdb9c316a7fc3957b618932e78bee3361fb",
     "https://deno.land/x/copb@v1.0.1/mod.ts": "664b6af5d0bf0339e3461ac69e6b06f052a322b7bfc1ec2fbc701fb525c56ba3",
     "https://deno.land/x/copb@v1.0.1/version.ts": "e1ce0be2da17592e301891cbffa0f00490c987be292434b852022c81d4d6800e"

--- a/fp_test.ts
+++ b/fp_test.ts
@@ -1,7 +1,4 @@
-import {
-  assertArrayIncludes,
-  assertEquals,
-} from "https://deno.land/std@0.84.0/testing/asserts.ts";
+import { assertArrayIncludes, assertEquals } from "./test_deps.ts";
 import { c, p } from "https://deno.land/x/copb@v1.0.1/mod.ts";
 import * as mod from "./mod.ts";
 import * as fp from "./fp.ts";

--- a/lib/combiners_test.ts
+++ b/lib/combiners_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.84.0/testing/asserts.ts";
+import { assertEquals } from "../test_deps.ts";
 import * as combiners from "./combiners.ts";
 
 // TODO: Test for mutability and state

--- a/lib/effectors_test.ts
+++ b/lib/effectors_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.84.0/testing/asserts.ts";
+import { assertEquals } from "../test_deps.ts";
 import * as effectors from "./effectors.ts";
 import { take } from "./transformers.ts";
 import { increments } from "./generators.ts";

--- a/lib/generators_test.ts
+++ b/lib/generators_test.ts
@@ -1,7 +1,4 @@
-import {
-  assert,
-  assertEquals,
-} from "https://deno.land/std@0.84.0/testing/asserts.ts";
+import { assert, assertEquals } from "../test_deps.ts";
 import * as generators from "./generators.ts";
 import { sum } from "./reducers.ts";
 

--- a/lib/internal/util_test.ts
+++ b/lib/internal/util_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.84.0/testing/asserts.ts";
+import { assertEquals } from "../../test_deps.ts";
 import * as util from "./util.ts";
 import { take } from "../../mod.ts";
 

--- a/lib/reducers_test.ts
+++ b/lib/reducers_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.84.0/testing/asserts.ts";
+import { assertEquals } from "../test_deps.ts";
 import * as reducers from "./reducers.ts";
 import { concat } from "./combiners.ts";
 import { increments, range } from "./generators.ts";

--- a/lib/transformers.ts
+++ b/lib/transformers.ts
@@ -641,7 +641,7 @@ export function fuse<T>(iter: Iterable<T>): IterableCircular<T> {
  * @example
  * ```ts
  * import * as iter from "https://deno.land/x/iter/mod.ts";
- * import { assert } from "https://deno.land/std@0.84.0/testing/asserts.ts";
+ * import { assert } from "../test_deps.ts";
  *
  * const peekable = iter.peekable(iter.create.range(5));
  *

--- a/lib/transformers_test.ts
+++ b/lib/transformers_test.ts
@@ -1,8 +1,4 @@
-import {
-  assert,
-  assertEquals,
-  assertThrows,
-} from "https://deno.land/std@0.84.0/testing/asserts.ts";
+import { assert, assertEquals, assertThrows } from "../test_deps.ts";
 import * as transformers from "./transformers.ts";
 import * as create from "./generators.ts";
 import { stripIterable } from "./internal/util.ts";
@@ -49,6 +45,7 @@ Deno.test("flatMap", async (t) => {
 
     // @ts-expect-error: iterable != readonlyArray
     assertEquals(it.flatMap(f), testSpreadClone);
+    // @ts-expect-error: iterable != Array
     assertEquals(it.map(f).flat(), testSpreadClone);
     assertEquals(
       [...transformers.flat(transformers.map(it, f))],

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,0 +1,4 @@
+export { assert } from "https://deno.land/std@0.208.0/assert/assert.ts";
+export { assertThrows } from "https://deno.land/std@0.208.0/assert/assert_throws.ts";
+export { assertEquals } from "https://deno.land/std@0.208.0/assert/assert_equals.ts";
+export { assertArrayIncludes } from "https://deno.land/std@0.208.0/assert/assert_array_includes.ts";


### PR DESCRIPTION
## Summary

- resolves #16

## Description

- added `test_deps.ts` to centralize dependency.
- migrated from deprecated `std/testing` to `std/assert`.